### PR TITLE
Prepare qubit function

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,9 @@ SimulaQron - simple quantum network simulator
 =============================================
 
 The purpose of this simulator of quantum network nodes is to allow you to develop new applications for
-a future quantum internet, while of course right now we do not yet have real quantum network nodes available for testing.
+a future quantum internet, while of course right now we do not yet have real quantum network nodes available for testing. 
+
+Importantly, SimulaQron is an application level simulator, with the sole purpose on exploring abstraction layers and how to program a quantum network. If you are interested in a simulator that can assess, for example, the performance of quantum repeaters or their placement, QuTech is developing a separate lower level simulator that can also model timing delays. This lower level simulator has a very different purpose and performs a discrete event simulation in order to determine the effect of the timing of classical communication on repeater protocols. A first version of the low level simulator will only be available in 2018.
 
 Documentation and examples are explained in the html documentation 
 https://stephaniewehner.github.io/SimulaQron/PreBetaDocs/index.html

--- a/local/setup.py
+++ b/local/setup.py
@@ -36,6 +36,7 @@ from SimulaQron.general.hostConfig import *
 from qutip import *
 
 import logging
+import numpy as np
 import time
 
 # logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG)
@@ -172,3 +173,20 @@ def assemble_qubit(realM, imagM):
 
 	return Qobj(M)
 
+
+def prepare_qubit(a, b):
+    """Prepares a qubit in the state a|0> + b|1>"""
+    if round(abs(a)**2 + abs(b)**2, 10) != 1:
+        raise ValueError('Sum of absolute squares of a and b must be equal to 1')
+
+    if b == 0:
+        return basis(2, 0) * basis(2, 0).dag()
+
+    qubit = basis(2, 0)
+    theta = 2 * np.arccos(a)
+    phi = -1.j * np.log(b / np.sin(theta / 2))
+
+    # rotation to perform on qubit
+    rotation = rz(phi) * ry(theta) * rz(-phi)
+    prepared_qubit = rotation * qubit
+    return prepared_qubit * prepared_qubit.dag()

--- a/tests/auto/local/testAll.sh
+++ b/tests/auto/local/testAll.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python testPrepareQubit.py
+

--- a/tests/auto/local/testPrepareQubit.py
+++ b/tests/auto/local/testPrepareQubit.py
@@ -1,0 +1,49 @@
+from SimulaQron.virtNode.crudeSimulator import simpleEngine
+from SimulaQron.local.setup import prepare_qubit
+
+import numpy as np
+import nose
+
+
+def check_probabilities(alpha, beta):
+    se = simpleEngine()
+    expected_pa = abs(alpha) ** 2
+    expected_pb = abs(beta) ** 2
+    a, b = 0, 0
+
+    for i in range(1000):
+        qb = prepare_qubit(alpha, beta)
+        se.add_qubit(qb)
+
+        outcome = se.measure_qubit(0)
+        a += outcome == 0
+        b += outcome == 1
+
+    pa = a / 1000
+    pb = b / 1000
+
+    nose.tools.assert_almost_equal(pa, expected_pa, delta=0.1 * expected_pa)
+    nose.tools.assert_almost_equal(pb, expected_pb, delta=0.1 * expected_pb)
+
+
+def test_prepare_qubit_0():
+    yield check_probabilities, 1, 0
+
+
+def test_prepare_qubit_1():
+    yield check_probabilities, 0, 1
+
+
+def test_prepare_qubit_equal():
+    yield check_probabilities, 1 / np.sqrt(2), 1 / np.sqrt(2)
+
+
+def test_prepare_qubit_unequal():
+    yield check_probabilities, 1 / np.sqrt(3), np.sqrt(2 / 3)
+
+
+def test_prepare_qubit_exception():
+    nose.tools.assert_raises(ValueError, prepare_qubit, 1, 1)
+
+
+nose.main(argv=['','-v']).runTests()


### PR DESCRIPTION
This pull request adds a function to prepare a qubit in the state a |0> + b |1> for valid input values of a and b. This is accomplished by rotating a qubit in state |0> along the z, y, and z axes through the angles phi, theta, and -phi respectively, computed using the specified values for a and b.

The function is tested by preparing a qubit in a specific state and measuring it. This is done a large number of times, subsequently calculating whether the measured relative frequencies of alpha and beta approximate their expected probabilities.
