### PR TITLE
Fixed error-handling when maxQubits in a node is reached.

### DIFF
--- a/cqc/backend/cqcProtocol.py
+++ b/cqc/backend/cqcProtocol.py
@@ -847,12 +847,14 @@ class CQCProtocol(Protocol):
 				return False
 
 			virt = yield self.factory.virtRoot.callRemote("new_qubit_inreg",self.factory.qReg)
+			if not virt: # if no more qubits
+				raise quantumError("No more qubits available")
 			q = CQCQubit(cmd.qubit_id, int(time.time()), virt)
 			self.factory.qubitList[(app_id,q_id)] = q
 			logging.debug("CQC %s: Requested new qubit (%d,%d)",self.name,app_id, q_id)
-		except Error:
-			logging.error("CQC %s: Error creating qubit", self.name)
-			self._send_back_cqc(cqc_header, CQC_ERR_GENERAL)
+		except quantumError: # if no more qubits
+			logging.error("CQC %s: Maximum number of qubits reached.", self.name)
+			self._send_back_cqc(cqc_header, CQC_ERR_NOQUBIT)
 			self.factory._lock.release()
 			return False
 

--- a/virtNode/crudeSimulator.py
+++ b/virtNode/crudeSimulator.py
@@ -71,10 +71,11 @@ class simpleEngine(quantumEngine):
 		v = basis(2,0)
 		newQubit = v * v.dag()
 
+
 		try:
 			num = self.add_qubit(newQubit)
 			return num
-		except Error:
+		except quantumError:
 			raise quantumError("Out of qubits.")
 			return(-1)
 

--- a/virtNode/quantum.py
+++ b/virtNode/quantum.py
@@ -84,6 +84,7 @@ class simulatedQubit(pb.Referenceable):
 		Make this a fresh qubit.
 		"""
 
+
 		# Create a fresh qubit in the |0> state
 		num = self.register.add_fresh_qubit()
 		self.num = num

--- a/virtNode/virtual.py
+++ b/virtNode/virtual.py
@@ -318,7 +318,8 @@ class virtualNode(pb.Root):
 			newNum = self.get_virtual_id()
 			newQubit = virtualQubit(self.myID, self.myID, simQubit, newNum)
 			self.virtQubits.append(newQubit)
-		except Error:
+		except quantumError:
+			newQubit = None
 			logging.error("VIRTUAL NODE %s: Maximum number of qubits reached.", self.myID.name)
 		finally:
 			self._release_global_lock()
@@ -349,9 +350,11 @@ class virtualNode(pb.Root):
 			newNum = self.get_virtual_id()
 			newQubit = virtualQubit(self.myID, self.myID, simQubit, newNum)
 			self.virtQubits.append(newQubit)
+		except quantumError: # if no more qubits
+			newQubit = None
+			logging.error("VIRTUAL NODE %s: Maximum number of qubits reached.", self.myID.name)
 		finally:
 			self._release_global_lock()
-
 
 		return newQubit
 


### PR DESCRIPTION
This includes typos where Error was written instead of quantumError and made it such that the cqc-backend now returns a CQC_ERR_NOQUBITS message if this is the case