### PR TITLE
Prepare qubit native

### DIFF
--- a/examples/nativeMode/prepareQubit/classicalNet.cfg
+++ b/examples/nativeMode/prepareQubit/classicalNet.cfg
@@ -1,0 +1,11 @@
+# Network configuration file
+# 
+# For each host its informal name, as well as its location in the network must
+# be listed.
+#
+# [name], [hostname], [port number]
+#
+
+Alice, localhost, 8811
+
+

--- a/examples/nativeMode/prepareQubit/doNew.sh
+++ b/examples/nativeMode/prepareQubit/doNew.sh
@@ -1,0 +1,3 @@
+
+ps aux | grep python | grep Test | awk {'print $2'} | xargs kill -9
+sh run.sh

--- a/examples/nativeMode/prepareQubit/measureTest.py
+++ b/examples/nativeMode/prepareQubit/measureTest.py
@@ -1,0 +1,189 @@
+#
+# Copyright (c) 2017, Stephanie Wehner and Axel Dahlberg
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. All advertising materials mentioning features or use of this software
+#    must display the following acknowledgement:
+#    This product includes software developed by Stephanie Wehner, QuTech.
+# 4. Neither the name of the QuTech organization nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER ''AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import sys, os
+sys.path.insert(0, os.environ.get('NETSIM'))
+
+from twisted.spread import pb
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks, returnValue, DeferredList, Deferred
+
+from SimulaQron.virtNode.basics import *
+from SimulaQron.virtNode.quantum import *
+from SimulaQron.general.hostConfig import *
+from SimulaQron.virtNode.crudeSimulator import *
+
+from SimulaQron.local.setup import *
+
+###
+#
+# To write your on node, you must:
+# - Decide: is it a server or client on the classical network (or both)? This will be defined via the file
+# classicalNet.cfg: if it's listed there then a server will be started.
+#
+# - If the node acts as a server, fill in the code in localNode above with your own actions. Provide methods
+#   for the clients on the classical network to call remotely.
+#
+# - If the node acts as a client, fill in the code for runClientNode below.
+#
+# See the examples/ and test/ folders for inspiration.
+
+
+#####################################################################################################
+#
+# runClientNode
+#
+# This will be run on the local node if all communication links are set up (to the virtual node
+# quantum backend, as well as the nodes in the classical communication network), and the local classical
+# communication server is running (if applicable).
+#
+@inlineCallbacks
+def runClientNode(qReg, virtRoot, myName, classicalNet):
+	"""
+	Code to execute for the local client node. Called if all connections are established.
+
+	Arguments
+	qReg		quantum register (twisted object supporting remote method calls)
+	virtRoot	virtual quantum ndoe (twisted object supporting remote method calls)
+	myName		name of this node (string)
+	classicalNet	servers in the classical communication network (dictionary of hosts)
+	"""
+
+	logging.debug("LOCAL %s: Running client side program.",myName)
+
+	a = 1 / np.sqrt(2)
+	b = 1 / np.sqrt(2)
+	pa = 0
+	pb = 0
+	expected_pa = abs(a) ** 2
+	expected_pb = abs(b) ** 2
+
+	for i in range(100):
+		qubit = yield virtRoot.callRemote("new_qubit_inreg", qReg)
+		yield from prepare_qubit(a, b, qubit)
+		measurement = yield qubit.callRemote("measure")
+		pa += measurement == 0
+		pb += measurement == 1
+
+	pa /= 100
+	pb /= 100
+
+	logging.debug("Expected p(a) = %s, expected p(b) = %s", expected_pa, expected_pb)
+	logging.debug("Measured p(a) = %s, measured p(b) = %s", pa, pb)
+
+	# Stop the server and client - you want to delete this if the nodes acts as a server
+	reactor.stop()
+
+
+def prepare_qubit(a, b, qubit):
+	# convert to float for twisted
+	theta = (2 * np.arccos(a)).item()
+	# take only real part for twisted
+	phi = (-1.j * np.log(b / np.sin(theta / 2))).real
+	y = [0, 1, 0]
+	z = [0, 0, 1]
+	yield qubit.callRemote("apply_rotation", z, phi)
+	yield qubit.callRemote("apply_rotation", y, theta)
+	yield qubit.callRemote("apply_rotation", z, -phi)
+
+#####################################################################################################
+#
+# localNode
+#
+# This will be run if the local node acts as a server on the classical communication network,
+# accepting remote method calls from the other nodes.
+
+class localNode(pb.Root):
+
+	def __init__(self, node, classicalNet):
+
+		self.node = node
+		self.classicalNet = classicalNet
+
+		self.virtRoot = None
+		self.qReg = None
+
+	def set_virtual_node(self, virtRoot):
+		self.virtRoot = virtRoot
+
+	def set_virtual_reg(self, qReg):
+		self.qReg = qReg
+
+	def remote_test(self):
+		return "Tested!"
+
+	# This can be called by Alice (or other clients on the classical network) to inform Bob
+	# of an event. Your code goes here.
+	# @inlineCallbacks
+	def remote_tell_bob(self, someInfo):
+
+		# Uncomment inlineCallbacks if you use yield here
+		# Also remove the pass statement when executing actual code
+		pass
+
+#####################################################################################################
+#
+# main
+#
+# This can stay the same for any example you run
+#
+
+def main():
+
+	# In this example, we are Alice
+	myName = "Alice"
+
+
+	# This file defines the network of virtual quantum nodes
+	virtualFile = os.environ.get('NETSIM') + "/config/virtualNodes.cfg"
+
+	# This file defines the nodes acting as servers in the classical communication network
+	classicalFile = "./classicalNet.cfg"
+
+	# Read configuration files for the virtual quantum, as well as the classical network
+	virtualNet = networkConfig(virtualFile)
+	classicalNet = networkConfig(classicalFile)
+
+	# Check if we should run a local classical server. If so, initialize the code
+	# to handle remote connections on the classical communication network
+	if myName in classicalNet.hostDict:
+		lNode = localNode(classicalNet.hostDict[myName], classicalNet)
+	else:
+		lNode = None
+
+	# Set up the local classical server if applicable, and connect to the virtual
+	# node and other classical servers. Once all connections are set up, this will
+	# execute the function runClientNode
+	setup_local(myName, virtualNet, classicalNet, lNode, runClientNode)
+
+
+##################################################################################################
+logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG)
+main()

--- a/examples/nativeMode/prepareQubit/prepareTest.py
+++ b/examples/nativeMode/prepareQubit/prepareTest.py
@@ -1,0 +1,182 @@
+#
+# Copyright (c) 2017, Stephanie Wehner and Axel Dahlberg
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. All advertising materials mentioning features or use of this software
+#    must display the following acknowledgement:
+#    This product includes software developed by Stephanie Wehner, QuTech.
+# 4. Neither the name of the QuTech organization nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER ''AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import sys, os
+sys.path.insert(0, os.environ.get('NETSIM'))
+
+from twisted.spread import pb
+from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks, returnValue, DeferredList, Deferred
+
+from SimulaQron.virtNode.basics import *
+from SimulaQron.virtNode.quantum import *
+from SimulaQron.general.hostConfig import *
+from SimulaQron.virtNode.crudeSimulator import *
+
+from SimulaQron.local.setup import *
+
+###
+#
+# To write your on node, you must:
+# - Decide: is it a server or client on the classical network (or both)? This will be defined via the file
+# classicalNet.cfg: if it's listed there then a server will be started.
+#
+# - If the node acts as a server, fill in the code in localNode above with your own actions. Provide methods
+#   for the clients on the classical network to call remotely.
+#
+# - If the node acts as a client, fill in the code for runClientNode below.
+#
+# See the examples/ and test/ folders for inspiration.
+
+
+#####################################################################################################
+#
+# runClientNode
+#
+# This will be run on the local node if all communication links are set up (to the virtual node
+# quantum backend, as well as the nodes in the classical communication network), and the local classical
+# communication server is running (if applicable).
+#
+@inlineCallbacks
+def runClientNode(qReg, virtRoot, myName, classicalNet):
+	"""
+	Code to execute for the local client node. Called if all connections are established.
+
+	Arguments
+	qReg		quantum register (twisted object supporting remote method calls)
+	virtRoot	virtual quantum ndoe (twisted object supporting remote method calls)
+	myName		name of this node (string)
+	classicalNet	servers in the classical communication network (dictionary of hosts)
+	"""
+
+	logging.debug("LOCAL %s: Runing client side program.",myName)
+
+	qubit = yield virtRoot.callRemote("new_qubit_inreg", qReg)
+
+	a = 1 / np.sqrt(2)
+	b = 1 / np.sqrt(2)
+
+	yield from prepare_qubit(a, b, qubit)
+
+	q = yield qubit.callRemote("get_qubit")
+	logging.debug("%s", q)
+
+	# Stop the server and client - you want to delete this if the nodes acts as a server
+	reactor.stop()
+
+
+
+def prepare_qubit(a, b, qubit):
+	# convert to float for twisted
+	theta = (2 * np.arccos(a)).item()
+	# take only real part for twisted
+	phi = (-1.j * np.log(b / np.sin(theta / 2))).real
+	y = [0, 1, 0]
+	z = [0, 0, 1]
+	yield qubit.callRemote("apply_rotation", z, phi)
+	yield qubit.callRemote("apply_rotation", y, theta)
+	yield qubit.callRemote("apply_rotation", z, -phi)
+
+
+#####################################################################################################
+#
+# localNode
+#
+# This will be run if the local node acts as a server on the classical communication network,
+# accepting remote method calls from the other nodes.
+
+class localNode(pb.Root):
+
+	def __init__(self, node, classicalNet):
+
+		self.node = node
+		self.classicalNet = classicalNet
+
+		self.virtRoot = None
+		self.qReg = None
+
+	def set_virtual_node(self, virtRoot):
+		self.virtRoot = virtRoot
+
+	def set_virtual_reg(self, qReg):
+		self.qReg = qReg
+
+	def remote_test(self):
+		return "Tested!"
+
+	# This can be called by Alice (or other clients on the classical network) to inform Bob
+	# of an event. Your code goes here.
+	# @inlineCallbacks
+	def remote_tell_bob(self, someInfo):
+
+		# Uncomment inlineCallbacks if you use yield here
+		# Also remove the pass statement when executing actual code
+		pass
+
+#####################################################################################################
+#
+# main
+#
+# This can stay the same for any example you run
+#
+
+def main():
+
+	# In this example, we are Alice
+	myName = "Alice"
+
+
+	# This file defines the network of virtual quantum nodes
+	virtualFile = os.environ.get('NETSIM') + "/config/virtualNodes.cfg"
+
+	# This file defines the nodes acting as servers in the classical communication network
+	classicalFile = "./classicalNet.cfg"
+
+	# Read configuration files for the virtual quantum, as well as the classical network
+	virtualNet = networkConfig(virtualFile)
+	classicalNet = networkConfig(classicalFile)
+
+	# Check if we should run a local classical server. If so, initialize the code
+	# to handle remote connections on the classical communication network
+	if myName in classicalNet.hostDict:
+		lNode = localNode(classicalNet.hostDict[myName], classicalNet)
+	else:
+		lNode = None
+
+	# Set up the local classical server if applicable, and connect to the virtual
+	# node and other classical servers. Once all connections are set up, this will
+	# execute the function runClientNode
+	setup_local(myName, virtualNet, classicalNet, lNode, runClientNode)
+
+
+##################################################################################################
+logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG)
+main()
+

--- a/examples/nativeMode/prepareQubit/run.sh
+++ b/examples/nativeMode/prepareQubit/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd "$NETSIM/examples/nativeMode/graphState"
+python bobTest.py &
+python charlieTest.py &
+python davidTest.py &
+python aliceTest.py

--- a/examples/nativeMode/prepareQubit/run.sh
+++ b/examples/nativeMode/prepareQubit/run.sh
@@ -1,7 +1,4 @@
 #!/bin/sh
 
-cd "$NETSIM/examples/nativeMode/graphState"
-python bobTest.py &
-python charlieTest.py &
-python davidTest.py &
-python aliceTest.py
+cd "$NETSIM/examples/nativeMode/prepareQubit"
+python measureTest.py


### PR DESCRIPTION
This pull request adds the prepare qubit example to the `nativeMode`. I have been trying to add nose tests similar to those of the qutip functionality, but this has proven to be quite involved so this has not been added yet. What is included is a `measureTest` which calculates the probabilities |a|^2 and |b|^2 by preparing and measuring a qubit 100 times.